### PR TITLE
Squashing Some Bugs

### DIFF
--- a/rosperch/change-gpio-perms.sh
+++ b/rosperch/change-gpio-perms.sh
@@ -5,7 +5,7 @@
 # access to it and allowing you to run code
 # with GPIO pins without sudo privileges
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 sudo groupadd gpio

--- a/rosperch/scripts/auto_code/auto_square.py
+++ b/rosperch/scripts/auto_code/auto_square.py
@@ -7,7 +7,7 @@
 # Motor command code is adapted from the UTAP 2020
 # code at https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries and messages

--- a/rosperch/scripts/auto_code/launcher_for_auto_square.py
+++ b/rosperch/scripts/auto_code/launcher_for_auto_square.py
@@ -8,7 +8,7 @@
 # from the UTAP 2020 code at 
 # https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries and messages

--- a/rosperch/scripts/joy_controller.py
+++ b/rosperch/scripts/joy_controller.py
@@ -10,7 +10,7 @@
 # Based on information from:
 # https://www.kernel.org/doc/Documentation/input/joystick-api.txt
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries

--- a/rosperch/scripts/simple_motor_test/controller.py
+++ b/rosperch/scripts/simple_motor_test/controller.py
@@ -9,7 +9,7 @@
 # ROS talker/listener node code based on tutorials at:
 # https://github.com/ros/ros_tutorials
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries

--- a/rosperch/scripts/simple_motor_test/motor_code.py
+++ b/rosperch/scripts/simple_motor_test/motor_code.py
@@ -9,7 +9,7 @@
 # ROS talker/listener node code based on tutorials at:
 # https://github.com/ros/ros_tutorials
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries

--- a/rosperch/scripts/simple_motor_test/receiver.py
+++ b/rosperch/scripts/simple_motor_test/receiver.py
@@ -9,7 +9,7 @@
 # ROS talker/listener node code based on tutorials at:
 # https://github.com/ros/ros_tutorials
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries

--- a/rosperch/scripts/wip/9dof_pub.py
+++ b/rosperch/scripts/wip/9dof_pub.py
@@ -3,7 +3,7 @@
 # This program gets and prints out values
 # from the NXP Absolute Orientation Breakout.
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 import time

--- a/rosperch/scripts/wip/auto_driver.py
+++ b/rosperch/scripts/wip/auto_driver.py
@@ -7,7 +7,7 @@
 # Motor command code is adapted from the UTAP 2020
 # code at https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 
@@ -81,8 +81,8 @@ def drive(dist):
     t = dist/perch_speed_straight # How long to stay in this state/execute command for
     while (curr_time - start_time) < t:
         curr_time = time.time()
-        GPIO.output(GR1,GPIO.HIGH) # Go forward        
-        GPIO.output(BL1,GPIO.HIGH) # Go forward
+        GPIO.output(GR1,GPIO.LOW) # Go forward        
+        GPIO.output(BL1,GPIO.LOW) # Go forward
         pwm.channels[GR1_PWM].duty_cycle = 0xFFFF # Full speed. Be sure to adjust these for drift
         pwm.channels[BL1_PWM].duty_cycle = 0xFFFF # Full speed. Be sure to adjust these for drift
         systemready = False # Sets system state

--- a/rosperch/scripts/wip/auto_test.py
+++ b/rosperch/scripts/wip/auto_test.py
@@ -7,7 +7,7 @@
 # Motor command code is adapted from the UTAP 2020
 # code at https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries and messages

--- a/rosperch/scripts/wip/mission_commands.py
+++ b/rosperch/scripts/wip/mission_commands.py
@@ -8,7 +8,7 @@
 # from the UTAP 2020 code at
 # https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 

--- a/rosperch/scripts/wip/mission_launcher.py
+++ b/rosperch/scripts/wip/mission_launcher.py
@@ -8,7 +8,7 @@
 # from the UTAP 2020 code at 
 # https://github.com/jdicecco/UTAP/
 # License:
-# Software License Agreement (GPLv3 License)
+# Software License Agreement (BSD License)
 # Find the full agreement at https://github.com/amichael1227/ROSPerch/blob/master/LICENSE
 
 # Imports the necessary libraries and messages


### PR DESCRIPTION
Fixed an issue where all the license tags at the top said GPLv3 instead of BSD, also resolved issue #5 motor_commands.py by swapping HIGH to LOW in the drive command within auto_driver.py, thus making the robot drive straight when the drive command is issued.

Closes #5 